### PR TITLE
Restore assertion on Exception message

### DIFF
--- a/src/jvmTest/kotlin/com/jakewharton/byteunits/BinaryByteUnitTest.kt
+++ b/src/jvmTest/kotlin/com/jakewharton/byteunits/BinaryByteUnitTest.kt
@@ -84,16 +84,22 @@ class BinaryByteUnitTest {
   }
 
   @Test fun formatNegativeValuesThrows() {
-    assertFailsWith<IllegalArgumentException>(message = "bytes < 0: -1") {
+    assertFailsWith<IllegalArgumentException> {
       BinaryByteUnit.format(-1)
+    }.also {
+      assertEquals("bytes < 0: -1", it.message)
     }
-    assertFailsWith<IllegalArgumentException>(message = "bytes < 0: -1") {
+    assertFailsWith<IllegalArgumentException> {
       BinaryByteUnit.format(-1, "#.##")
+    }.also {
+      assertEquals("bytes < 0: -1", it.message)
     }
 
     val format: NumberFormat = DecimalFormat("#.##", DecimalFormatSymbols(Locale.FRENCH))
-    assertFailsWith<IllegalArgumentException>(message = "bytes < 0: -1") {
+    assertFailsWith<IllegalArgumentException> {
       BinaryByteUnit.format(-1, format)
+    }.also {
+      assertEquals("bytes < 0: -1", it.message)
     }
   }
 }

--- a/src/jvmTest/kotlin/com/jakewharton/byteunits/BitUnitTest.kt
+++ b/src/jvmTest/kotlin/com/jakewharton/byteunits/BitUnitTest.kt
@@ -85,16 +85,22 @@ class BitUnitTest {
   }
 
   @Test fun formatNegativeValuesThrows() {
-    assertFailsWith<IllegalArgumentException>(message = "bits < 0: -1") {
+    assertFailsWith<IllegalArgumentException> {
       BitUnit.format(-1)
+    }.also {
+      assertEquals("bits < 0: -1", it.message)
     }
-    assertFailsWith<IllegalArgumentException>(message = "bits < 0: -1") {
+    assertFailsWith<IllegalArgumentException> {
       BitUnit.format(-1, "#.##")
+    }.also {
+      assertEquals("bits < 0: -1", it.message)
     }
 
     val format: NumberFormat = DecimalFormat("#.##", DecimalFormatSymbols(Locale.FRENCH))
-    assertFailsWith<IllegalArgumentException>(message = "bits < 0: -1") {
+    assertFailsWith<IllegalArgumentException> {
       BitUnit.format(-1, format)
+    }.also {
+      assertEquals("bits < 0: -1", it.message)
     }
   }
 }

--- a/src/jvmTest/kotlin/com/jakewharton/byteunits/DecimalByteUnitTest.kt
+++ b/src/jvmTest/kotlin/com/jakewharton/byteunits/DecimalByteUnitTest.kt
@@ -82,19 +82,19 @@ class DecimalByteUnitTest {
     assertFailsWith<IllegalArgumentException> {
       DecimalByteUnit.format(-1)
     }.also {
-      assertEquals("bits < 0: -1", it.message)
+      assertEquals("bytes < 0: -1", it.message)
     }
     assertFailsWith<IllegalArgumentException> {
       DecimalByteUnit.format(-1, "#.##")
     }.also {
-      assertEquals("bits < 0: -1", it.message)
+      assertEquals("bytes < 0: -1", it.message)
     }
 
     val format: NumberFormat = DecimalFormat("#.##", DecimalFormatSymbols(Locale.FRENCH))
     assertFailsWith<IllegalArgumentException> {
       DecimalByteUnit.format(-1, format)
     }.also {
-      assertEquals("bits < 0: -1", it.message)
+      assertEquals("bytes < 0: -1", it.message)
     }
   }
 }

--- a/src/jvmTest/kotlin/com/jakewharton/byteunits/DecimalByteUnitTest.kt
+++ b/src/jvmTest/kotlin/com/jakewharton/byteunits/DecimalByteUnitTest.kt
@@ -79,16 +79,22 @@ class DecimalByteUnitTest {
   }
 
   @Test fun formatNegativeValuesThrows() {
-    assertFailsWith<IllegalArgumentException>(message = "bits < 0: -1") {
+    assertFailsWith<IllegalArgumentException> {
       DecimalByteUnit.format(-1)
+    }.also {
+      assertEquals("bits < 0: -1", it.message)
     }
-    assertFailsWith<IllegalArgumentException>(message = "bits < 0: -1") {
+    assertFailsWith<IllegalArgumentException> {
       DecimalByteUnit.format(-1, "#.##")
+    }.also {
+      assertEquals("bits < 0: -1", it.message)
     }
 
     val format: NumberFormat = DecimalFormat("#.##", DecimalFormatSymbols(Locale.FRENCH))
-    assertFailsWith<IllegalArgumentException>(message = "bits < 0: -1") {
+    assertFailsWith<IllegalArgumentException> {
       DecimalByteUnit.format(-1, format)
+    }.also {
+      assertEquals("bits < 0: -1", it.message)
     }
   }
 }


### PR DESCRIPTION
Kotlin's [`assertFailsWith()`](https://kotlinlang.org/api/latest/kotlin.test/kotlin.test/assert-fails-with.html)'s `message` parameter is not used for validation, but for debug only in case the assertion fails.

> If the assertion fails, the specified [message](https://kotlinlang.org/api/latest/kotlin.test/kotlin.test/assert-fails-with.html#kotlin.test$assertFailsWith(kotlin.String?,%20kotlin.Function0((kotlin.Unit)))/message) is used unless it is null as a prefix for the failure message.


Introduced in https://github.com/JakeWharton/byteunits/pull/19